### PR TITLE
Added new public repositories

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,10 @@
 import { PublicRepo } from './components';
 
+const aferox = new PublicRepo('aferox', {
+	description: 'Implementations and utilities for github.com/spf13/afero',
+	githubChecks: ['Build and Test'],
+});
+
 const devctl = new PublicRepo('devctl', {
 	description: 'Dev productivity CLI',
 	githubChecks: ['Build and Test'],
@@ -7,6 +12,11 @@ const devctl = new PublicRepo('devctl', {
 
 const go = new PublicRepo('go', {
 	description: 'Random Go crap',
+	githubChecks: ['Build and Test'],
+});
+
+const goMake = new PublicRepo('go-make', {
+	description: 'Makefile parsing library for Go',
 	githubChecks: ['Build and Test'],
 });
 
@@ -27,8 +37,10 @@ const theclusterOperator = new PublicRepo('thecluster-operator', {
 });
 
 export const repos = [
+	aferox.repo.name,
 	devctl.repo.name,
 	go.repo.name,
+	goMake.repo.name,
 	pulumiBaremetal.repo.name,
 	thecluster.repo.name,
 	theclusterOperator.repo.name,


### PR DESCRIPTION
Two new public repositories, 'aferox' and 'go-make', have been added. These repositories include their respective descriptions and GitHub checks. They are also now included in the exported 'repos' array.
